### PR TITLE
pass new argument reject to promise

### DIFF
--- a/src/compile/tsc.js
+++ b/src/compile/tsc.js
@@ -57,7 +57,7 @@ class TSBuilder {
 
     compileMain() {
 
-        return new Promise((res) => {
+        return new Promise((res, rej) => {
 
             const outFile = path.join(config.projectRoot, config.build, 'main.ts');
             const tscPath = path.join(config.projectRoot, 'node_modules', '.bin', 'tsc');


### PR DESCRIPTION
# Prerequisites

```cmd
> yarn --version
1.12.3

> ng --version
Angular CLI: 7.1.3
Node: 11.3.0
OS: win32 x64
Angular: 7.1.3

> ngr --version
2.0.1
```

# Current Behavior

On build application using JIT compiler I get this error:

```cmd
> ngr build jit
NGR ERROR ReferenceError: rej is not defined
    at ReadFileContext.fs.readFile [as callback] (C:\Users\MyUser\AppData\Roaming\npm\node_modules\angular-rollup\src\compile\tsc.js:93:21)
    at FSReqCallback.readFileAfterOpen [as oncomplete] (fs.js:245:13)
```

Inspecting that file, function `rej` is not defined. I supose that is enough pass it as argument to promise. https://github.com/steveblue/angular2-rollup/blob/33a791058097144f6b2c5dfe39d29ea6a0be07ad/src/compile/tsc.js#L58-L99


## Steps to Reproduce

1. Create a new project and install dependencies

```cmd
> ngr new my-app --yarn
> yarn install
```

2. Generate dist files using JIT Compiler.

```cmd
> ngr build jit
NGR ERROR ReferenceError: rej is not defined
    at ReadFileContext.fs.readFile [as callback] (C:\Users\MyUser\AppData\Roaming\npm\node_modules\angular-rollup\src\compile\tsc.js:93:21)
    at FSReqCallback.readFileAfterOpen [as oncomplete] (fs.js:245:13)
```